### PR TITLE
adds capability to execute async stuff inside cpu tasks

### DIFF
--- a/ace/analysis.py
+++ b/ace/analysis.py
@@ -18,7 +18,8 @@ from dataclasses import dataclass, field, asdict
 from typing import Union, Optional, Any
 
 import ace
-import ace.system
+
+# import ace.system
 
 from ace.data_model import (
     AnalysisModel,

--- a/ace/api/base.py
+++ b/ace/api/base.py
@@ -16,6 +16,7 @@ from ace.system.events import EventHandler
 class AceAPI:
     def __init__(self, system: ACESystem, api_key: str = None):
         assert isinstance(system, ACESystem)
+        assert api_key is None or isinstance(api_key, str)
         self.system = system
         self.api_key = api_key
 

--- a/ace/api/remote.py
+++ b/ace/api/remote.py
@@ -21,6 +21,7 @@ from ace.data_model import (
 )
 from ace.analysis import RootAnalysis, AnalysisModuleType, Observable
 from ace.api.base import AceAPI
+from ace.system import ACESystem
 from ace.system.requests import AnalysisRequest
 from ace.constants import ERROR_AMT_VERSION, ERROR_AMT_EXTENDED_VERSION, ERROR_AMT_DEP
 from ace.system.events import EventHandler
@@ -60,16 +61,32 @@ def _raise_exception_from_error_model(error: ErrorModel):
 
 
 class RemoteAceAPI(AceAPI):
+    def __init__(
+        self,
+        system: ACESystem,
+        api_key: str,
+        url: str,
+        client_args: Optional[list] = None,
+        client_kwargs: Optional[dict] = None,
+    ):
+        super().__init__(system, api_key)
 
-    api_key = None
+        self.url = url
+        self.client_args = client_args if client_args else []
+        self.client_kwargs = client_kwargs if client_kwargs else {}
+
+        if "base_url" not in self.client_kwargs:
+            self.client_kwargs["base_url"] = url
 
     def get_client(self):
         kwargs = {}
         kwargs.update(self.client_kwargs)
-        if "headers" not in kwargs:
-            kwargs["headers"] = {}
+        if self.api_key:
+            if "headers" not in kwargs:
+                kwargs["headers"] = {}
 
-        kwargs["headers"].update({"X-API-Key": self.api_key})
+            kwargs["headers"].update({"X-API-Key": self.api_key})
+
         return AsyncClient(*self.client_args, **kwargs)
 
     # alerting

--- a/ace/module/base.py
+++ b/ace/module/base.py
@@ -1,7 +1,6 @@
 # vim: ts=4:sw=4:et:cc=120
 #
 
-import inspect
 import multiprocessing
 import uuid
 
@@ -21,49 +20,57 @@ class AnalysisModule:
     type: AnalysisModuleType = None
     limit: int = None
     timeout: Union[float, int] = None
+    is_multi_process: bool = False
 
     def __init__(
-        self, type: Optional[AnalysisModuleType] = None, limit: Optional[int] = None, timeout: Union[int, float] = None
+        self,
+        type: Optional[AnalysisModuleType] = None,
+        limit: Optional[int] = None,
+        timeout: Union[int, float] = None,
+        is_multi_process: Optional[bool] = None,
     ):
+        assert type is None or isinstance(type, AnalysisModuleType)
+        assert limit is None or isinstance(limit, int)
+        assert timeout is None or (isinstance(timeout, int) or isinstance(timeout, float))
+        assert is_multi_process is None or isinstance(is_multi_process, bool)
+
         if type:
             self.type = type
         elif self.type is None:
             self.type = AnalysisModuleType(f"anonymous-{uuid.uuid4()}", "")
 
-        if limit:
+        # if this is True then execute_analysis is executed on a separate process so the async loop is not tied up
+        # this is important for analysis modules that do a lot of CPU intensive tasks *IN PYTHON*
+        # if you're I/O bound (network, file or external process) then you don't need this
+        if is_multi_process is not None:
+            self.is_multi_process = is_multi_process
+
+        if limit is not None:
             self.limit = limit
         elif self.limit is None:
-            if self.is_async():
-                self.limit = DEFAULT_ASYNC_LIMIT
-            else:
+            if self.is_multi_process:
                 self.limit = multiprocessing.cpu_count()
+            else:
+                self.limit = DEFAULT_ASYNC_LIMIT
 
-        if timeout:
+        if timeout is not None:
             self.timeout = timeout
 
-    def is_async(self) -> bool:
-        return inspect.iscoroutinefunction(self.execute_analysis)
-
-    def execute_analysis(self, root: RootAnalysis, observable: Observable, analysis: Analysis):
-        raise NotImplementedError()
-
-    def upgrade(self):
-        pass
-
-    # XXX I think we can get rid of this with a correct design
-    def load(self):
-        pass
-
-    def __hash__(self):
-        return self.type.name.__hash__()
-
-
-class AsyncAnalysisModule(AnalysisModule):
     async def execute_analysis(self, root: RootAnalysis, observable: Observable, analysis: Analysis):
         raise NotImplementedError()
 
     async def upgrade(self):
         pass
 
+    # XXX I think we can get rid of this with a correct design
     async def load(self):
         pass
+
+    def __hash__(self):
+        return self.type.name.__hash__()
+
+
+class MultiProcessAnalysisModule(AnalysisModule):
+    """An analysis module that executes on a separate process."""
+
+    is_multi_process = True

--- a/ace/module/base.py
+++ b/ace/module/base.py
@@ -56,6 +56,8 @@ class AnalysisModule:
         if timeout is not None:
             self.timeout = timeout
 
+        # TODO implement a custom default timeout here
+
     async def execute_analysis(self, root: RootAnalysis, observable: Observable, analysis: Analysis):
         raise NotImplementedError()
 

--- a/ace/system/base/events.py
+++ b/ace/system/base/events.py
@@ -44,7 +44,6 @@ class EventBaseInterface:
     async def fire_event(self, event: str, event_args: Optional[Any] = None):
         """Fires the event with the given JSON argument."""
         assert isinstance(event, str) and event
-
         get_logger().debug(f"fired event {event}")
         return await self.i_fire_event(Event(name=event, args=event_args))
 

--- a/ace/system/distributed/storage.py
+++ b/ace/system/distributed/storage.py
@@ -29,7 +29,6 @@ async def api_store_content(
     expiration_date: Optional[str] = Form(None, description="An optional time at which the content should expire."),
     custom: Optional[str] = Form(None, description="Optional custom data to associate to the content."),
 ):
-
     if expiration_date:
         expiration_date = datetime.fromisoformat(expiration_date)
 

--- a/ace/system/local/storage.py
+++ b/ace/system/local/storage.py
@@ -78,6 +78,8 @@ class LocalStorageInterface(DatabaseStorageInterface):
         with open(file_path, "wb") as fp:
             fp.write(data)
 
+        get_logger().info(f"stored file content {meta.name} {sha256} at {file_path}")
+
         with self.get_db() as db:
             db.merge(
                 Storage(
@@ -120,7 +122,7 @@ class LocalStorageInterface(DatabaseStorageInterface):
                     yield data
 
         except IOError as e:
-            get_logger().debug(f"unable to get content stream for {sha256}: {e}")
+            get_logger().warning(f"unable to get content stream for {sha256}: {e}")
             yield None
 
     async def i_load_file(self, sha256: str, path: str) -> Union[ContentMetadata, None]:

--- a/ace/system/redis/__init__.py
+++ b/ace/system/redis/__init__.py
@@ -1,7 +1,10 @@
 # vim: ts=4:sw=4:et:cc=120
 
 import contextlib
+import os
+import threading
 
+from ace.logging import get_logger
 from ace.system import ACESystem
 
 import aioredis
@@ -17,10 +20,14 @@ CONFIG_REDIS_DB = "/ace/core/redis/db"
 CONFIG_REDIS_POOL_SIZE = "/ace/core/redis/pool_size"
 
 
+def _pool_key():
+    return "{}:{}".format(os.getpid(), threading.get_ident())
+
+
 class RedisACESystem(RedisAlertTrackingInterface, RedisEventInterface, RedisWorkQueueManagerInterface, ACESystem):
     """A partial implementation of the ACE core implemented using Redis."""
 
-    redis_connection_pool = None
+    pools = {}  # key = _pool_key(), value = aioredis.create_redis_pool
 
     @contextlib.asynccontextmanager
     async def get_redis_connection(self):
@@ -33,12 +40,14 @@ class RedisACESystem(RedisAlertTrackingInterface, RedisEventInterface, RedisWork
             pass
 
     async def _get_redis_connection(self):
-        host = await self.get_config_value(CONFIG_REDIS_HOST)
-        port = await self.get_config_value(CONFIG_REDIS_PORT)
-        db = await self.get_config_value(CONFIG_REDIS_DB, default=0)
-        pool_size = await self.get_config_value(CONFIG_REDIS_DB, default=10)
+        # if the pid or tid change then we create a new pool
+        pool_key = _pool_key()
+        if pool_key not in self.pools:
+            host = await self.get_config_value(CONFIG_REDIS_HOST)
+            port = await self.get_config_value(CONFIG_REDIS_PORT)
+            db = await self.get_config_value(CONFIG_REDIS_DB, default=0)
+            pool_size = await self.get_config_value(CONFIG_REDIS_DB, default=100)
 
-        if self.redis_connection_pool is None:
             if host and port:
                 connection_info = (host, port)
             else:
@@ -47,6 +56,16 @@ class RedisACESystem(RedisAlertTrackingInterface, RedisEventInterface, RedisWork
             if not connection_info:
                 raise ValueError("missing redis connection settings")
 
-            self.redis_connection_pool = await aioredis.create_redis_pool(connection_info)
+            get_logger().info(f"connecting to redis {connection_info} ({pool_key})")
+            self.pools[pool_key] = await aioredis.create_redis_pool(connection_info)
+            get_logger().debug(f"connected to redis {connection_info} ({pool_key})")
 
-        return self.redis_connection_pool
+        return self.pools[pool_key]
+
+    async def close_redis_connections(self):
+        pool_key = _pool_key()
+        get_logger().info(f"closing connection pool to redis ({pool_key})")
+        if pool_key in self.pools:
+            self.pools[pool_key].close()
+            await self.pools[pool_key].wait_closed()
+            del self.pools[pool_key]

--- a/ace/system/remote/__init__.py
+++ b/ace/system/remote/__init__.py
@@ -3,7 +3,10 @@
 # remote API implementation of the ACE Engine
 #
 
+from typing import Optional
+
 from ace.api.base import AceAPI
+from ace.api.remote import RemoteAceAPI
 from ace.system import ACESystem
 from ace.system.remote.alerting import RemoteAlertTrackingInterface
 from ace.system.remote.analysis_tracking import RemoteAnalysisTrackingInterface
@@ -30,5 +33,14 @@ class RemoteACESystem(
     RemoteWorkQueueManagerInterface,
     ACESystem,
 ):
+    def __init__(
+        self, url, api_key, *args, client_args: Optional[list] = None, client_kwargs: Optional[dict] = None, **kwargs
+    ):
+        super().__init__(*args, *kwargs)
+
+        self.url = url
+        self.api_key = api_key
+        self.api = RemoteAceAPI(self, api_key, url, client_args=client_args, client_kwargs=client_kwargs)
+
     def get_api(self) -> AceAPI:
-        raise NotImplementedError()
+        return self.api

--- a/ace/system/remote/__init__.py
+++ b/ace/system/remote/__init__.py
@@ -40,7 +40,14 @@ class RemoteACESystem(
 
         self.url = url
         self.api_key = api_key
+        self.client_args = client_args
+        self.client_kwargs = client_kwargs
         self.api = RemoteAceAPI(self, api_key, url, client_args=client_args, client_kwargs=client_kwargs)
 
     def get_api(self) -> AceAPI:
+        # if the api key changed then create a new api object to use
+        # if self.api_key != self.api.api_key:
+        # breakpoint()
+        # self.api = RemoteAceAPI(self, self.api_key, self.url, client_args=self.client_args, client_kwargs=self.client_kwargs)
+
         return self.api

--- a/tests/ace/module/conftest.py
+++ b/tests/ace/module/conftest.py
@@ -1,52 +1,94 @@
 # vim: ts=4:sw=4:et:cc=120
 #
 
+import os.path
+import os
+
 from ace.crypto import initialize_encryption_settings
+from ace.module.manager import AnalysisModuleManager, CONCURRENCY_MODE_PROCESS, CONCURRENCY_MODE_THREADED
 from ace.logging import get_logger
 from ace.system.distributed import app
 
-from tests.systems import DistributedACETestSystem, RemoteACETestSystem
+from tests.systems import DistributedACETestSystem, RemoteACETestSystem, RemoteACETestSystemProcess
 
 import pytest
 
 
 @pytest.fixture(scope="session")
-async def remote_system(redis):
+def redis_url(redis):
+    """Returns the URL to use to connect to the test redis instance."""
+    return "unix://{}".format(redis.connection_pool.connection_kwargs["path"])
+
+
+@pytest.fixture(scope="function", params=[CONCURRENCY_MODE_THREADED, CONCURRENCY_MODE_PROCESS])
+async def manager(request, redis, redis_url, tmpdir):
+
+    # initialize the "server side" system
     app.state.system = DistributedACETestSystem()
     from ace.system.redis import CONFIG_REDIS_HOST, CONFIG_REDIS_PORT
 
     # pull the unix path from the redislist connection pool
-    await app.state.system.set_config(
-        CONFIG_REDIS_HOST, "unix://{}".format(redis.connection_pool.connection_kwargs["path"])
-    )
+    await app.state.system.set_config(CONFIG_REDIS_HOST, redis_url)
 
     # initialize encryption settings with a password of "test"
     app.state.system.encryption_settings = initialize_encryption_settings("test")
     app.state.system.encryption_settings.load_aes_key("test")
 
-    # await app.state.system.initialize()
-    await app.state.system.reset()
+    # set the storage root for the local file system storage
+    from ace.system.local.storage import CONFIG_DB_FILE_STORAGE_ROOT
+
+    await app.state.system.set_config(CONFIG_DB_FILE_STORAGE_ROOT, str(tmpdir))
+
+    await app.state.system.initialize()
+    await app.state.system.reset()  # XXX do we need this here?
 
     app.state.system.root_api_key = await app.state.system.create_api_key("test_root", "test_root", is_admin=True)
     await app.state.system.start()
 
-    test_system = RemoteACETestSystem()
-    await test_system.initialize()
+    # initialize the "client side" system
+    system = RemoteACETestSystem(app.state.system.root_api_key)
+    await system.initialize()
+    await system.start()
 
-    # copy the auto generated root api key to the client
-    test_system.api.api_key = app.state.system.root_api_key
-    get_logger().info(f"using api key {test_system.api.api_key}")
+    #
+    # this is complex so it requires some explanation
+    # the manager has a reference to a RemoteACESystem called "system"
+    # when manager.system is initialized, it also initializes app.state.system
+    # which is the "server" side of the connection (the system that the FastAPI calls use)
+    # so when app.state.system gets initialized, everything gets set up (redis, database, encryption settings, etc...)
+    #
+    # now, the CPUTaskExecutor objects run in their own blank process
+    # so they get the class type and init args used to create their own RemoteACESystem to use
+    # to communicate with the core (passed in from the manager)
+    # (the class type and init args are what are passed in on the Manager constructor)
+    #
+    # since the "server" side is already set up, we need a different RemoteACESystem type
+    # that does NOT re-initialize everything that was already set up
+    # so the RemoteACETestSystemClient (note the Client part) is used instead
+    # which receives the configuration and settings stored in app.state.system
+    #
 
-    await test_system.start()
+    if request.param == CONCURRENCY_MODE_THREADED:
+        system_class = RemoteACETestSystem
+        system_args = (system.api.api_key,)
+    elif request.param == CONCURRENCY_MODE_PROCESS:
+        system_class = RemoteACETestSystemProcess
+        system_args = (redis_url, system.api.api_key, app.state.system.encryption_settings)
 
-    yield test_system
+    _manager = AnalysisModuleManager(system, system_class, system_args, concurrency_mode=request.param)
 
-    await test_system.stop()
+    yield _manager
+
+    # stop the distributed system on the "server" side
     await app.state.system.stop()
 
+    # reset redis to default state
+    redis.flushall()
 
-@pytest.fixture(autouse=True, scope="function")
-async def reset_remote_system(remote_system):
-    await app.state.system.reset()
-    app.state.system.root_api_key = await app.state.system.create_api_key("test", "root", is_admin=True)
-    remote_system.api.api_key = app.state.system.root_api_key
+    # blast away the database
+    if os.path.exists("ace_distributed.db"):
+        os.remove("ace_distributed.db")
+
+    # drop the reference to the distributed system on the "server" side
+    # this will force this to be recreated every time
+    delattr(app.state, "system")

--- a/tests/ace/module/test_core_integration.py
+++ b/tests/ace/module/test_core_integration.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 import os.path
 import tempfile
+import shutil
 
 import ace.analysis
 
@@ -15,13 +16,14 @@ from ace.system.distributed import app
 from ace.system.events import EventHandler, Event
 from ace.module.base import AnalysisModule, MultiProcessAnalysisModule
 from ace.module.manager import AnalysisModuleManager, CONCURRENCY_MODE_PROCESS, CONCURRENCY_MODE_THREADED
+from tests.systems import RemoteACETestSystem
 
 import pytest
 
 
 @pytest.mark.asyncio
 @pytest.mark.system
-async def test_basic_analysis_async(remote_system):
+async def test_basic_analysis_async(manager):
 
     # basic analysis module
     class TestAsyncAnalysisModule(AnalysisModule):
@@ -38,20 +40,18 @@ async def test_basic_analysis_async(remote_system):
     module = TestAsyncAnalysisModule()
 
     # register the type to the core
-    await remote_system.register_analysis_module_type(module.type)
+    await manager.system.register_analysis_module_type(module.type)
 
     # submit a root for analysis so we create a new job
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
-    # create a new manager to run our analysis modules
-    manager = AnalysisModuleManager(remote_system)
     manager.add_module(module)
     await manager.run_once()
 
     # check the results in the core
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(module.type)
     assert analysis
@@ -74,30 +74,27 @@ class TestMultiProcessAnalysisModule(AnalysisModule):
         return True
 
 
-# @pytest.mark.parametrize("concurrency_mode", [CONCURRENCY_MODE_THREADED, CONCURRENCY_MODE_PROCESS])
-@pytest.mark.parametrize("concurrency_mode", [CONCURRENCY_MODE_PROCESS])
 @pytest.mark.asyncio
 @pytest.mark.system
-async def test_basic_analysis_sync(concurrency_mode, remote_system):
+async def test_basic_analysis_sync(manager):
 
     # create an instance of it
     module = TestMultiProcessAnalysisModule()
 
     # register the type to the core
-    await remote_system.register_analysis_module_type(module.type)
+    await manager.system.register_analysis_module_type(module.type)
 
     # submit a root for analysis so we create a new job
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
     # create a new manager to run our analysis modules
-    manager = AnalysisModuleManager(remote_system, concurrency_mode=concurrency_mode)
     manager.add_module(module)
     await manager.run_once()
 
     # check the results in the core
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(module.type)
     assert analysis
@@ -107,7 +104,7 @@ async def test_basic_analysis_sync(concurrency_mode, remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_force_stop_stuck_async_task(remote_system):
+async def test_force_stop_stuck_async_task(manager):
     control = asyncio.Event()
 
     class CustomAnalysisModule(AnalysisModule):
@@ -121,13 +118,12 @@ async def test_force_stop_stuck_async_task(remote_system):
 
     # register the type to the core
     amt = AnalysisModuleType("test", "")
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system)
     module = CustomAnalysisModule(amt)
     manager.add_module(module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
@@ -152,16 +148,19 @@ class StuckAnalysisModule(MultiProcessAnalysisModule):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_force_stop_stuck_sync_task(remote_system):
+async def test_force_stop_stuck_sync_task(manager):
+    # there's nothing you can do when concurrency is threaded
+    if manager.concurrency_mode == CONCURRENCY_MODE_THREADED:
+        pytest.skip("cannot test in concurrency_mode {manager.concurrency_mode}")
+
     # register the type to the core
     amt = AnalysisModuleType("test", "")
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system, concurrency_mode=CONCURRENCY_MODE_PROCESS)
     module = StuckAnalysisModule(amt)
     manager.add_module(module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
@@ -178,25 +177,24 @@ async def test_force_stop_stuck_sync_task(remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_raised_exception_during_async_analysis(remote_system):
+async def test_raised_exception_during_async_analysis(manager):
     class CustomAnalysisModule(AnalysisModule):
         async def execute_analysis(self, root, observable, analysis):
             raise RuntimeError("failure")
 
     amt = AnalysisModuleType("test", "")
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system)
     module = CustomAnalysisModule(amt)
     manager.add_module(module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
     await manager.run_once()
 
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(amt)
 
@@ -211,21 +209,20 @@ class FailingAnalysisModule(MultiProcessAnalysisModule):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_raised_exception_during_sync_analysis(remote_system):
+async def test_raised_exception_during_sync_analysis(manager):
     amt = AnalysisModuleType("test", "")
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system)
     module = FailingAnalysisModule(amt)
     manager.add_module(module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
     await manager.run_once()
 
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(amt)
 
@@ -255,7 +252,10 @@ class SimpleSyncAnalysisModule(MultiProcessAnalysisModule):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_crashing_sync_analysis_module(remote_system):
+async def test_crashing_sync_analysis_module(manager):
+
+    if manager.concurrency_mode == CONCURRENCY_MODE_THREADED:
+        pytest.skip("cannot test in concurrency_mode {manager.concurrency_mode}")
 
     sync = asyncio.Event()
 
@@ -271,18 +271,17 @@ async def test_crashing_sync_analysis_module(remote_system):
 
     amt_crashing = AnalysisModuleType("crash_test", "")
     amt_ok = AnalysisModuleType("ok", "")
-    await remote_system.register_analysis_module_type(amt_crashing)
-    await remote_system.register_analysis_module_type(amt_ok)
+    await manager.system.register_analysis_module_type(amt_crashing)
+    await manager.system.register_analysis_module_type(amt_ok)
 
     # this is only supported in CONCURRENCY_MODE_PROCESS
-    manager = AnalysisModuleManager(remote_system, concurrency_mode=CONCURRENCY_MODE_PROCESS)
     crashing_module = CrashingAnalysisModule(amt_crashing)
     ok_module = SimpleSyncAnalysisModule(amt_ok)
 
     manager.add_module(crashing_module)
     manager.add_module(ok_module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "crash")
     await root.submit()
 
@@ -291,7 +290,7 @@ async def test_crashing_sync_analysis_module(remote_system):
     # wait for analysis to complete
     assert await sync.wait()
 
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(amt_crashing)
 
@@ -310,7 +309,11 @@ async def test_crashing_sync_analysis_module(remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_upgraded_version_analysis_module(remote_system):
+async def test_upgraded_version_analysis_module(manager):
+    # cannot test this in process concurrency mode because it requires shared events
+    if manager.concurrency_mode == CONCURRENCY_MODE_PROCESS:
+        pytest.skip("cannot test in concurrency_mode {manager.concurrency_mode}")
+
     # NOTE for this one we don't need to test both sync and async because
     # this check comes before analysis module execution (same for both)
     step_1 = asyncio.Event()
@@ -324,17 +327,16 @@ async def test_upgraded_version_analysis_module(remote_system):
                 return
 
     amt = AnalysisModuleType("test", "", version="1.0.0")
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system)
     module = CustomAnalysisModule(type=amt)
     manager.add_module(module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
-    root_2 = remote_system.new_root()
+    root_2 = manager.system.new_root()
     observable_2 = root_2.add_observable("test", "test")
 
     async def _upgrade():
@@ -342,7 +344,7 @@ async def test_upgraded_version_analysis_module(remote_system):
         nonlocal root_2
         await step_1.wait()
         updated_amt = AnalysisModuleType("test", "", version="1.0.1")
-        await remote_system.register_analysis_module_type(updated_amt)
+        await manager.system.register_analysis_module_type(updated_amt)
         await root_2.submit()
 
     upgrade_task = asyncio.create_task(_upgrade())
@@ -350,7 +352,7 @@ async def test_upgraded_version_analysis_module(remote_system):
     await upgrade_task
 
     # in this case the version mismatch just causes the manger to exit
-    root = await remote_system.get_root_analysis(root_2)
+    root = await manager.system.get_root_analysis(root_2)
     observable = root.get_observable(observable)
     # so no analysis should be seen
     assert observable.get_analysis(amt) is None
@@ -358,7 +360,7 @@ async def test_upgraded_version_analysis_module(remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_upgraded_extended_version_async_analysis_module(remote_system):
+async def test_upgraded_extended_version_async_analysis_module(manager):
     """Tests the ability of an analysis module to update extended version data."""
 
     #
@@ -385,17 +387,16 @@ async def test_upgraded_extended_version_async_analysis_module(remote_system):
             self.type.extended_version = ["intel:v2"]
 
     amt = AnalysisModuleType("test", "", extended_version=["intel:v1"])
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system)
     module = CustomAnalysisModule(type=amt)
     manager.add_module(module)
 
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
-    root_2 = remote_system.new_root()
+    root_2 = manager.system.new_root()
     observable_2 = root_2.add_observable("test", "test")
 
     async def _update_intel():
@@ -404,7 +405,7 @@ async def test_upgraded_extended_version_async_analysis_module(remote_system):
         await step_1.wait()
         # update the extended version data for this module type
         updated_amt = AnalysisModuleType("test", "", extended_version=["intel:v2"])
-        await remote_system.register_analysis_module_type(updated_amt)
+        await manager.system.register_analysis_module_type(updated_amt)
         await root_2.submit()
 
     async def _shutdown():
@@ -419,7 +420,7 @@ async def test_upgraded_extended_version_async_analysis_module(remote_system):
     await upgrade_task
     await shutdown_task
 
-    root = await remote_system.get_root_analysis(root_2)
+    root = await manager.system.get_root_analysis(root_2)
     observable = root.get_observable(observable)
     assert (await observable.get_analysis(amt).get_details())["extended_version"] == ["intel:v2"]
 
@@ -435,11 +436,8 @@ class UpgradableAnalysisModule(MultiProcessAnalysisModule):
 @pytest.mark.parametrize("concurrency_mode", [CONCURRENCY_MODE_THREADED, CONCURRENCY_MODE_PROCESS])
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_upgraded_extended_version_sync_analysis_module(concurrency_mode, remote_system):
+async def test_upgraded_extended_version_sync_analysis_module(concurrency_mode, redis_url, manager):
     """Tests the ability of a sync analysis module to update extended version data."""
-
-    amt = AnalysisModuleType("test", "", extended_version=["intel:v1"])
-    await remote_system.register_analysis_module_type(amt)
 
     # we want to bail after the first execution of the module
     class CustomAnalysisModuleManager(AnalysisModuleManager):
@@ -451,39 +449,57 @@ async def test_upgraded_extended_version_sync_analysis_module(concurrency_mode, 
 
             return result
 
-    manager = CustomAnalysisModuleManager(remote_system, concurrency_mode=concurrency_mode)
-    module = UpgradableAnalysisModule(type=amt)
-    manager.add_module(module)
+    custom_manager = CustomAnalysisModuleManager(
+        manager.system, RemoteACETestSystem, (manager.system.api.api_key,), concurrency_mode=concurrency_mode
+    )
 
-    root = remote_system.new_root()
+    root_analysis_completed = asyncio.Event()
+
+    class CustomEventHandler(EventHandler):
+        async def handle_event(self, event: Event):
+            root_analysis_completed.set()
+
+        async def handle_exception(self, event: str, exception: Exception):
+            pass
+
+    # TODO when events are distributed modify this to use that
+    await app.state.system.register_event_handler(EVENT_ANALYSIS_ROOT_COMPLETED, CustomEventHandler())
+
+    amt = AnalysisModuleType("test", "", extended_version=["intel:v1"])
+    await custom_manager.system.register_analysis_module_type(amt)
+
+    module = UpgradableAnalysisModule(type=amt)
+    custom_manager.add_module(module)
+
+    root = custom_manager.system.new_root()
     observable = root.add_observable("test", "test")
 
     async def _update_intel():
-        nonlocal manager
+        nonlocal custom_manager
         # wait for the event loop to start
-        await manager.event_loop_starting_event.wait()
+        await custom_manager.event_loop_starting_event.wait()
         # update the extended version data for this module type
         updated_amt = AnalysisModuleType("test", "", extended_version=["intel:v2"])
-        await remote_system.register_analysis_module_type(updated_amt)
+        await custom_manager.system.register_analysis_module_type(updated_amt)
         # and then submit for analysis
         await root.submit()
 
     upgrade_task = asyncio.create_task(_update_intel())
-    await manager.run()
+    await custom_manager.run()
     await upgrade_task
+    await root_analysis_completed.wait()
 
-    root = await remote_system.get_root_analysis(root)
+    root = await custom_manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     assert (await observable.get_analysis(amt).get_details())["extended_version"] == ["intel:v2"]
 
 
-@pytest.mark.parametrize("concurrency_mode", [CONCURRENCY_MODE_THREADED, CONCURRENCY_MODE_PROCESS])
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_upgrade_analysis_module_failure(concurrency_mode, remote_system):
+async def test_upgrade_analysis_module_failure(manager):
 
     amt = AnalysisModuleType("test", "", extended_version=["intel:v1"])
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
     class CustomAnalysisModule(MultiProcessAnalysisModule):
         async def execute_analysis(self, *args, **kwargs):
@@ -492,12 +508,11 @@ async def test_upgrade_analysis_module_failure(concurrency_mode, remote_system):
         async def upgrade(self):
             raise RuntimeError()
 
-    manager = AnalysisModuleManager(remote_system, concurrency_mode=concurrency_mode)
     module = CustomAnalysisModule(type=amt)
     manager.add_module(module)
 
     amt = AnalysisModuleType("test", "", extended_version=["intel:v2"])
-    await remote_system.register_analysis_module_type(amt)
+    await manager.system.register_analysis_module_type(amt)
 
     # this should fail since the upgrade fails
     assert not await manager.run()
@@ -505,7 +520,7 @@ async def test_upgrade_analysis_module_failure(concurrency_mode, remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_async_module_timeout(remote_system):
+async def test_async_module_timeout(manager):
 
     # define a module that times out immediately
     class TimeoutAsyncAnalysisModule(AnalysisModule):
@@ -521,20 +536,19 @@ async def test_async_module_timeout(remote_system):
     module = TimeoutAsyncAnalysisModule()
 
     # register the type to the core
-    await remote_system.register_analysis_module_type(module.type)
+    await manager.system.register_analysis_module_type(module.type)
 
     # submit a root for analysis so we create a new job
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
     # create a new manager to run our analysis modules
-    manager = AnalysisModuleManager(remote_system)
     manager.add_module(module)
     await manager.run_once()
 
     # check the results in the core
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(module.type)
     assert analysis
@@ -551,7 +565,7 @@ class FileAnalysisModule(AnalysisModule):
             fp.write("test")
 
         await analysis.add_file(target_path)
-        os.rmdir(tmpdir)
+        shutil.rmtree(tmpdir)
 
 
 class MultiProcessFileAnalysisModule(FileAnalysisModule):
@@ -561,36 +575,35 @@ class MultiProcessFileAnalysisModule(FileAnalysisModule):
 @pytest.mark.parametrize("module_class", [FileAnalysisModule, MultiProcessFileAnalysisModule])
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_module_add_file(remote_system, tmpdir, module_class):
+async def test_module_add_file(manager, tmpdir, module_class):
     # adding file content is treated specially by the core since it has to upload and download the content
 
     # create an instance of it
     module = module_class()
 
     # register the type to the core
-    await remote_system.register_analysis_module_type(module.type)
+    await manager.system.register_analysis_module_type(module.type)
 
     # submit a root for analysis so we create a new job
-    root = remote_system.new_root()
+    root = manager.system.new_root()
     observable = root.add_observable("test", "test")
     await root.submit()
 
     # create a new manager to run our analysis modules
-    manager = AnalysisModuleManager(remote_system)
     manager.add_module(module)
     await manager.run_once()
 
     # check the results in the core
-    root = await remote_system.get_root_analysis(root)
+    root = await manager.system.get_root_analysis(root)
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(module.type)
     assert analysis
     file_observable = analysis.get_observable_by_type("file")
     assert file_observable
 
-    meta = await remote_system.get_content_meta(file_observable.value)
+    meta = await manager.system.get_content_meta(file_observable.value)
     assert meta.name == "test.txt"
     assert meta.sha256 == file_observable.value
 
-    content = await remote_system.get_content_bytes(file_observable.value)
+    content = await manager.system.get_content_bytes(file_observable.value)
     assert content.decode() == "test"

--- a/tests/ace/module/test_core_integration.py
+++ b/tests/ace/module/test_core_integration.py
@@ -151,7 +151,7 @@ class StuckAnalysisModule(MultiProcessAnalysisModule):
 async def test_force_stop_stuck_sync_task(manager):
     # there's nothing you can do when concurrency is threaded
     if manager.concurrency_mode == CONCURRENCY_MODE_THREADED:
-        pytest.skip("cannot test in concurrency_mode {manager.concurrency_mode}")
+        pytest.skip(f"cannot test in concurrency_mode {manager.concurrency_mode}")
 
     # register the type to the core
     amt = AnalysisModuleType("test", "")
@@ -255,7 +255,7 @@ class SimpleSyncAnalysisModule(MultiProcessAnalysisModule):
 async def test_crashing_sync_analysis_module(manager):
 
     if manager.concurrency_mode == CONCURRENCY_MODE_THREADED:
-        pytest.skip("cannot test in concurrency_mode {manager.concurrency_mode}")
+        pytest.skip(f"cannot test in concurrency_mode {manager.concurrency_mode}")
 
     sync = asyncio.Event()
 
@@ -312,7 +312,7 @@ async def test_crashing_sync_analysis_module(manager):
 async def test_upgraded_version_analysis_module(manager):
     # cannot test this in process concurrency mode because it requires shared events
     if manager.concurrency_mode == CONCURRENCY_MODE_PROCESS:
-        pytest.skip("cannot test in concurrency_mode {manager.concurrency_mode}")
+        pytest.skip(f"cannot test in concurrency_mode {manager.concurrency_mode}")
 
     # NOTE for this one we don't need to test both sync and async because
     # this check comes before analysis module execution (same for both)

--- a/tests/ace/module/test_manager.py
+++ b/tests/ace/module/test_manager.py
@@ -38,26 +38,26 @@ async def test_verify_registration(manager):
 
     assert await manager.system.register_analysis_module_type(amt)
 
-    manager = AnalysisModuleManager(remote_system)
-    manager.add_module(AnalysisModule(amt))
-    assert await manager.verify_registration()
+    custom_manager = AnalysisModuleManager(manager.system)
+    custom_manager.add_module(AnalysisModule(amt))
+    assert await custom_manager.verify_registration()
     # missing registration
     amt = AnalysisModuleType("missing", "")
-    manager = AnalysisModuleManager(remote_system)
-    manager.add_module(AnalysisModule(amt))
-    assert not await manager.verify_registration()
-    assert not await manager.run()
+    custom_manager = AnalysisModuleManager(manager.system)
+    custom_manager.add_module(AnalysisModule(amt))
+    assert not await custom_manager.verify_registration()
+    assert not await custom_manager.run()
     # version mismatch
     amt = AnalysisModuleType("test", "", version="1.0.1")
-    manager = AnalysisModuleManager(remote_system)
-    manager.add_module(AnalysisModule(amt))
-    assert not await manager.verify_registration()
-    assert not await manager.run()
+    custom_manager = AnalysisModuleManager(manager.system)
+    custom_manager.add_module(AnalysisModule(amt))
+    assert not await custom_manager.verify_registration()
+    assert not await custom_manager.run()
     # extended version mismatch
     amt = AnalysisModuleType("test", "", extended_version=["yara:71bec09d78fe6abdb94244a4cc89c740"])
-    manager = AnalysisModuleManager(remote_system)
-    manager.add_module(AnalysisModule(amt))
-    assert not await manager.verify_registration()
+    custom_manager = AnalysisModuleManager(manager.system)
+    custom_manager.add_module(AnalysisModule(amt))
+    assert not await custom_manager.verify_registration()
     # extended version mismatch but upgrade ok
     class UpgradableAnalysisModule(AnalysisModule):
         async def upgrade(self):
@@ -65,9 +65,9 @@ async def test_verify_registration(manager):
 
     # starts out with the wrong set of yara rules but upgrade() fixes that
     amt = AnalysisModuleType("test", "", extended_version=["yara:71bec09d78fe6abdb94244a4cc89c740"])
-    manager = AnalysisModuleManager(remote_system)
-    manager.add_module(UpgradableAnalysisModule(amt))
-    assert await manager.verify_registration()
+    custom_manager = AnalysisModuleManager(manager.system)
+    custom_manager.add_module(UpgradableAnalysisModule(amt))
+    assert await custom_manager.verify_registration()
 
 
 @pytest.mark.asyncio
@@ -86,37 +86,37 @@ async def test_scaling_task_creation(manager):
             return sum(iter(self.module_task_count.values()))
 
     amt = AnalysisModuleType("test", "")
-    result = await manager.system.register_analysis_module_type(amt)
-    manager = CustomManager(manager.system)
+    custom_manager = CustomManager(manager.system)
+    result = await custom_manager.system.register_analysis_module_type(amt)
     module = AnalysisModule(amt, limit=2)
-    manager.add_module(module)
+    custom_manager.add_module(module)
 
     # no tasks to start
-    assert manager.total_task_count() == 0
+    assert custom_manager.total_task_count() == 0
 
     # starts with one task
-    manager.initialize_module_tasks()
-    assert manager.total_task_count() == 1
+    custom_manager.initialize_module_tasks()
+    assert custom_manager.total_task_count() == 1
 
     # scale up to 2 tasks
-    manager.direction = SCALE_UP
-    result = await manager.module_loop(module, "test")
-    assert manager.total_task_count() == 2
+    custom_manager.direction = SCALE_UP
+    result = await custom_manager.module_loop(module, "test")
+    assert custom_manager.total_task_count() == 2
 
     # should not scale past limit
-    result = await manager.module_loop(module, "test")
-    assert manager.total_task_count() == 2
+    result = await custom_manager.module_loop(module, "test")
+    assert custom_manager.total_task_count() == 2
 
     # scale down to one task
-    manager.direction = SCALE_DOWN
-    result = await manager.module_loop(module, "test")
-    assert manager.total_task_count() == 1
+    custom_manager.direction = SCALE_DOWN
+    result = await custom_manager.module_loop(module, "test")
+    assert custom_manager.total_task_count() == 1
 
     # scale down does not drop below one task
-    result = await manager.module_loop(module, "test")
-    assert manager.total_task_count() == 1
+    result = await custom_manager.module_loop(module, "test")
+    assert custom_manager.total_task_count() == 1
 
     # after shutdown it drops to zero tasks
-    manager.shutdown = True
-    await manager.module_loop(module, "test")
-    assert manager.total_task_count() == 0
+    custom_manager.shutdown = True
+    await custom_manager.module_loop(module, "test")
+    assert custom_manager.total_task_count() == 0

--- a/tests/ace/module/test_manager.py
+++ b/tests/ace/module/test_manager.py
@@ -2,7 +2,7 @@
 #
 
 from ace.analysis import AnalysisModuleType
-from ace.module.base import AnalysisModule, AsyncAnalysisModule
+from ace.module.base import AnalysisModule
 from ace.module.manager import AnalysisModuleManager, SCALE_UP, SCALE_DOWN, NO_SCALING
 
 import pytest
@@ -11,10 +11,10 @@ import pytest
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_add_module(system):
-    class CustomAnalysisModule(AsyncAnalysisModule):
+    class CustomAnalysisModule(AnalysisModule):
         pass
 
-    class CustomAnalysisModule2(AsyncAnalysisModule):
+    class CustomAnalysisModule2(AnalysisModule):
         pass
 
     manager = AnalysisModuleManager(system)
@@ -40,27 +40,27 @@ async def test_verify_registration(system):
     assert await system.register_analysis_module_type(amt)
 
     manager = AnalysisModuleManager(system)
-    manager.add_module(AsyncAnalysisModule(amt))
+    manager.add_module(AnalysisModule(amt))
     assert await manager.verify_registration()
     # missing registration
     amt = AnalysisModuleType("missing", "")
     manager = AnalysisModuleManager(system)
-    manager.add_module(AsyncAnalysisModule(amt))
+    manager.add_module(AnalysisModule(amt))
     assert not await manager.verify_registration()
     assert not await manager.run()
     # version mismatch
     amt = AnalysisModuleType("test", "", version="1.0.1")
     manager = AnalysisModuleManager(system)
-    manager.add_module(AsyncAnalysisModule(amt))
+    manager.add_module(AnalysisModule(amt))
     assert not await manager.verify_registration()
     assert not await manager.run()
     # extended version mismatch
     amt = AnalysisModuleType("test", "", extended_version=["yara:71bec09d78fe6abdb94244a4cc89c740"])
     manager = AnalysisModuleManager(system)
-    manager.add_module(AsyncAnalysisModule(amt))
+    manager.add_module(AnalysisModule(amt))
     assert not await manager.verify_registration()
     # extended version mismatch but upgrade ok
-    class UpgradableAnalysisModule(AsyncAnalysisModule):
+    class UpgradableAnalysisModule(AnalysisModule):
         async def upgrade(self):
             self.type.extended_version = ["yara:6f5902ac237024bdd0c176cb93063dc4"]
 

--- a/tests/ace/module/test_manager.py
+++ b/tests/ace/module/test_manager.py
@@ -10,14 +10,13 @@ import pytest
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_add_module(remote_system):
+async def test_add_module(manager):
     class CustomAnalysisModule(AnalysisModule):
         pass
 
     class CustomAnalysisModule2(AnalysisModule):
         pass
 
-    manager = AnalysisModuleManager(remote_system)
     module = CustomAnalysisModule()
     assert manager.add_module(module) is module
     assert module in manager.analysis_modules
@@ -33,11 +32,11 @@ async def test_add_module(remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_verify_registration(remote_system):
+async def test_verify_registration(manager):
     # registration OK
     amt = AnalysisModuleType("test", "", extended_version=["yara:6f5902ac237024bdd0c176cb93063dc4"])
 
-    assert await remote_system.register_analysis_module_type(amt)
+    assert await manager.system.register_analysis_module_type(amt)
 
     manager = AnalysisModuleManager(remote_system)
     manager.add_module(AnalysisModule(amt))
@@ -73,7 +72,7 @@ async def test_verify_registration(remote_system):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_scaling_task_creation(remote_system):
+async def test_scaling_task_creation(manager):
     class CustomManager(AnalysisModuleManager):
         direction = SCALE_DOWN
 
@@ -87,8 +86,8 @@ async def test_scaling_task_creation(remote_system):
             return sum(iter(self.module_task_count.values()))
 
     amt = AnalysisModuleType("test", "")
-    result = await remote_system.register_analysis_module_type(amt)
-    manager = CustomManager(remote_system)
+    result = await manager.system.register_analysis_module_type(amt)
+    manager = CustomManager(manager.system)
     module = AnalysisModule(amt, limit=2)
     manager.add_module(module)
 

--- a/tests/ace/module/test_module.py
+++ b/tests/ace/module/test_module.py
@@ -4,25 +4,21 @@
 import multiprocessing
 
 from ace.analysis import AnalysisModuleType
-from ace.module.base import AnalysisModule, DEFAULT_ASYNC_LIMIT
+from ace.module.base import AnalysisModule, MultiProcessAnalysisModule, DEFAULT_ASYNC_LIMIT
 
 import pytest
 
 
 @pytest.mark.unit
 def test_analysis_module_constructor():
-    class AsyncAnalysisModule(AnalysisModule):
-        async def execute_analysis(self, root, observable, analysis):
-            pass
-
     # default sync module
-    module = AnalysisModule()
+    module = MultiProcessAnalysisModule()
     assert isinstance(module.type, AnalysisModuleType)
     assert module.limit == multiprocessing.cpu_count()
     assert module.timeout is None
 
     # default async module
-    module = AsyncAnalysisModule()
+    module = AnalysisModule()
     assert isinstance(module.type, AnalysisModuleType)
     assert module.limit == DEFAULT_ASYNC_LIMIT
     assert module.timeout is None

--- a/tests/systems.py
+++ b/tests/systems.py
@@ -96,13 +96,13 @@ class DistributedACETestSystem(RedisACETestSystem):
 
 class RemoteACETestSystem(RemoteACESystem, ThreadedACESystem):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.api = RemoteAceAPI(self)
-        self.api.client_args = []
-        self.api.client_kwargs = {
-            "app": app,
-            "base_url": "http://test",
-        }
+        super().__init__("http://test", None, client_args=[], client_kwargs={"app": app}, *args, **kwargs)
+        # self.api = RemoteAceAPI(self)
+        # self.api.client_args = []
+        # self.api.client_kwargs = {
+        # "app": app,
+        # "base_url": "http://test",
+        # }
 
-    def get_api(self):
-        return self.api
+    # def get_api(self):
+    # return self.api


### PR DESCRIPTION
Analysis modules that are CPU intensive must run on their own process (or thread.) But they also need to be able to execute the normal async routines available in the core (such as loading and storing files, analysis details, etc...)