### PR TITLE
crashed module debugging

### DIFF
--- a/ace/analysis.py
+++ b/ace/analysis.py
@@ -2042,7 +2042,9 @@ class RootAnalysis(Analysis, MergableObject):
             if await self.save():
                 return True
 
-            get_logger().debug(f"sync iteration {_}")
+            if _:
+                get_logger().info(f"sync iteration {_}")
+
             modified_root = await self.system.get_root_analysis(self)
             if modified_root.version == self.version:
                 raise RuntimeError("RootAnalysis.save() failed but version matches -- check logs for issues")

--- a/tests/ace/module/test_core_integration.py
+++ b/tests/ace/module/test_core_integration.py
@@ -245,11 +245,6 @@ class SimpleSyncAnalysisModule(MultiProcessAnalysisModule):
         analysis.set_details({"test": "test"})
 
 
-#
-# XXX this test has a timing issue
-#
-
-
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_crashing_sync_analysis_module(manager):
@@ -300,11 +295,16 @@ async def test_crashing_sync_analysis_module(manager):
     observable = root.get_observable(observable)
     analysis = observable.get_analysis(amt_ok)
 
-    # this one may or may not work depending on if you're using a local or remote api client
-    assert (
-        analysis.error_message == "okv1.0.0 process crashed when analyzing type test value crash"
-        and analysis.stack_trace
-    ) or await analysis.get_details() == {"test": "test"}
+    #
+    # the behavior of what happens to the other analysis modules that happen to
+    # be running in the same manager seems to be undefined, so there's really
+    # no way to test for that
+    #
+
+    # assert (
+    # analysis.error_message == "okv1.0.0 process crashed when analyzing type test value crash"
+    # and analysis.stack_trace
+    # ) or await analysis.get_details() == {"test": "test"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When an analysis module crashes (process exit), the behavior of the rest of the analysis modules running in the same manager is undefined, so can't really test for it.